### PR TITLE
fix: 修复 workspaceManager.parseWorkspaceCommand is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@
 // 重构：集中注册
 const { instances, getToolInstance } = require('./tools/registry.js');
 
-// 导入工作目录管理器
-const workspaceManager = require('./tools/workspaceManager.js');
+// 导入工作目录管理器实例
+const workspaceManager = instances.workspace_manager;
 
 // 处理命令行参数
 if (process.argv.includes('--help')) {


### PR DESCRIPTION
修复 index.js 中直接导入 WorkspaceManager 类导致的方法未定义错误，改用 registry.js 中已实例化的 workspace_manager 实例。\n\n关联 issue: #4